### PR TITLE
Added SELinux sample policy and enhanced RPM spec file

### DIFF
--- a/install/SELinux/README.txt
+++ b/install/SELinux/README.txt
@@ -1,0 +1,20 @@
+# webacula_bconsole.te SELinux Policy file
+
+To integrate webacula into a SELinux enabled system (Fedora, RHEL, CentOS; SL),
+you need to compile and install a SELinux policy for webacula which allows the 
+bconsole calls from apache httpd server.
+
+INSTALLATION:
+
+1. Install required packages:
+ yum install selinux-policy-devel
+ 
+2. Compile the policy source file into a policy package file:
+ make -f /usr/share/selinux/devel/Makefile
+
+3. Activate policy package:
+semodule -i webacula_bconsole.pp 
+
+4. Cleanup
+make -f /usr/share/selinux/devel/Makefile clean
+

--- a/install/SELinux/webacula_bconsole.te
+++ b/install/SELinux/webacula_bconsole.te
@@ -1,0 +1,24 @@
+# SELinux Policy Package source file for webacula
+# As webacula calls bconsole, we need a Policy to allow it.
+
+# prerequisites: Installed selinux-policy-devel rpm package
+# compile to pp file with command:
+# make -f /usr/share/selinux/devel/Makefile && semodule -i webacula_bconsole.pp 
+
+module webacula_bconsole 1.0;
+
+require {
+	type postgresql_port_t;
+	type httpd_t;
+	type hplip_port_t;
+	class tcp_socket name_connect;
+}
+
+#============= httpd_t ==============
+
+#!!!! This avc can be allowed using the boolean 'httpd_can_network_connect'
+allow httpd_t hplip_port_t:tcp_socket name_connect;
+
+#!!!! This avc can be allowed using one of the these booleans:
+#     httpd_can_network_connect, httpd_can_network_connect_db
+allow httpd_t postgresql_port_t:tcp_socket name_connect;

--- a/packaging/Fedora/build.sh
+++ b/packaging/Fedora/build.sh
@@ -86,6 +86,7 @@ rm -f -r "${RPM_TMP}/webacula-${VERSION}"
 echo -e "\ncopy files...\n"
 cd ${ROOT_DIR}
 cp -p -f "${SRC_DIR}/packaging/Fedora/webacula.spec" "${RPM_SPECS}/"
+cp -p -f "${SRC_DIR}/packaging/Fedora/*.patch "${RPM_SOURCES}/"
 
 echo -e "\n"
 

--- a/packaging/Fedora/webacula-5.5.2-apache.patch
+++ b/packaging/Fedora/webacula-5.5.2-apache.patch
@@ -1,0 +1,14 @@
+diff -up install/apache/webacula.conf.org install/apache/webacula.conf
+--- install/apache/webacula.conf.org	2013-09-11 09:53:14.431232615 +0200
++++ install/apache/webacula.conf	2013-09-11 09:53:40.686979709 +0200
+@@ -5,7 +5,9 @@
+ # Allows only localhost by default
+ #
+ 
+-LoadModule rewrite_module modules/mod_rewrite.so
++<IfModule !rewrite_module>
++  LoadModule rewrite_module modules/mod_rewrite.so
++</IfModule>
+ 
+ # AccessFileName .htaccess
+ # RewriteLog "/var/log/httpd/mod_rewrite.log"

--- a/packaging/Fedora/webacula-5.5.2-path.patch
+++ b/packaging/Fedora/webacula-5.5.2-path.patch
@@ -1,0 +1,16 @@
+diff -up html/index.php.org html/index.php
+--- html/index.php.org	2013-09-10 18:13:02.000000000 +0200
++++ html/index.php	2013-09-10 19:08:07.864302577 +0200
+@@ -19,10 +19,10 @@
+  */
+ 
+ define('WEBACULA_VERSION', '5.5.2' . ', build 2011.11.01');
+-define('BACULA_VERSION', 12); // Bacula Catalog version
++define('BACULA_VERSION', 14); // Bacula Catalog version
+ 
+ define('ROOT_DIR', dirname(dirname(__FILE__)) );
+-define('CACHE_DIR',  ROOT_DIR.'/data/cache' );
++define('CACHE_DIR', '/var/cache/webacula' );
+ 
+ defined('APPLICATION_ENV')
+     || define('APPLICATION_ENV', (getenv('APPLICATION_ENV') ? getenv('APPLICATION_ENV') : 'production'));

--- a/packaging/Fedora/webacula.spec
+++ b/packaging/Fedora/webacula.spec
@@ -1,6 +1,6 @@
 Name:          webacula
 Version:       5.5.2
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Web interface of a Bacula backup system
 Summary(ru):   Веб интерфейс для Bacula backup system
 
@@ -9,6 +9,9 @@ License:    GPLv3+
 URL:        http://webacula.sourceforge.net/
 Source0:    http://downloads.sourceforge.net/%{name}/%{name}-%{version}.tar.gz
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+Patch1:     webacula-5.5.2-path.patch
+Patch2:     webacula-5.5.2-apache.patch
 
 BuildArch:  noarch
 
@@ -44,6 +47,8 @@ Webacula - Web Bacula - веб интерфейс для Bacula backup system.
 
 %prep
 %setup -q
+%patch1 -p0 -b .cache
+%patch2 -p0 -b .apache
 
 
 
@@ -62,6 +67,8 @@ mkdir -p $RPM_BUILD_ROOT%{_datadir}/%{name}/html
 mkdir -p $RPM_BUILD_ROOT%{_datadir}/%{name}/languages
 mkdir -p $RPM_BUILD_ROOT%{_datadir}/%{name}/library
 mkdir -p $RPM_BUILD_ROOT%{_datadir}/%{name}/install
+
+mkdir -p %{buildroot}%{_localstatedir}/cache/%{name}
 
 cp ./application/config.ini  $RPM_BUILD_ROOT%{_sysconfdir}/%{name}/config.ini
 rm -f ./application/config.ini
@@ -101,10 +108,15 @@ rm -rf $RPM_BUILD_ROOT
 %lang(it) %{_datadir}/%{name}/languages/it
 %lang(pt) %{_datadir}/%{name}/languages/pt
 %lang(ru) %{_datadir}/%{name}/languages/ru
+%dir %attr(750, apache, apache) %{_localstatedir}/cache/%{name}
 
 
 
 %changelog
+* Tue Sep 10 2013 Robert Oschwald <robertoschwald@gmail.com> 5.5.2-2
+- Use systems cache dir
+- Load rewrite module conditionally if not loaded already
+
 * Sat Oct 29 2011 Yuri Timofeev <tim4dev@gmail.com> 5.5.2-1
 - Version 5.5.2
 


### PR DESCRIPTION
- SELinux sample policy file to integrate webacula into SELinux enforced systems
- Use systems cache dir to store runtime files (e.g. /var/cache/webacula)
- Load Apache HTTPD mod_rewrite module conditionally (prevents warning)
