### PR TITLE
 - added new setting days_to_show_jobs_terminated feature

### DIFF
--- a/application/config.ini
+++ b/application/config.ini
@@ -43,6 +43,11 @@ bacula.bconsolecmd = "-n -c /opt/bacula/etc/bconsole.conf"
 ;; Jobs with errors (last NN day(s)
 ; days_to_show_jobs_with_errors = 7
 
+
+;; As many days to show those Jobs that are terminated (default = 1)
+;; Jobs terminated (last NN day(s)
+;; days_to_show_jobs_terminated = 2
+
 ;; Show human readable short Job description instead of Bacula Job names (default = 0)
 ; avaliable optins : 0 | 1 | 2
 ; 0 - only show Bacula Job Name (behavior as in earlier versions)

--- a/application/controllers/FeedController.php
+++ b/application/controllers/FeedController.php
@@ -52,7 +52,7 @@ class FeedController extends MyClass_ControllerAclAction
         );
         // terminated Jobs
         $jobs = new Job();
-        $result = $jobs->getTerminatedJobs();
+        $result = $jobs->getTerminatedJobs(1);
         foreach ($result as $item) {
             // convert date to timestamp format
             $date = new Zend_Date($item['starttime'], 'YYYY-MM-dd HH:mm:ss');

--- a/application/controllers/JobController.php
+++ b/application/controllers/JobController.php
@@ -42,10 +42,18 @@ class JobController extends MyClass_ControllerAclAction
      */
     function terminatedAction()
     {
-        $this->view->title = $this->view->translate->_("Terminated Jobs (executed in last 24 hours)");
+        $terminatedDays = trim( $this->_request->getParam('days') );
+        if ( empty($terminatedDays) ) {
+            if ( empty($this->view->config->general->days_to_show_jobs_terminated) ) {
+                $terminatedDays = 1;
+            } else {
+                $terminatedDays = $this->view->config->general->days_to_show_jobs_terminated;
+            }
+        } 
+        $this->view->title = $this->view->translate->_("Terminated Jobs (executed in last " . ($terminatedDays*24) . " hours)");
         // get data from model
         $jobs = new Job();
-        $this->view->result = $jobs->getTerminatedJobs();
+        $this->view->result = $jobs->getTerminatedJobs($terminatedDays);
         $this->view->meta_refresh = 300; // meta http-equiv="refresh"
         $this->view->show_job_description = Zend_Registry::get('show_job_description');
     }
@@ -527,7 +535,7 @@ EOF"
             $this->_helper->layout->setLayout('dashboard');
         $this->view->title = $this->view->translate->_("Terminated Jobs (executed in last 24 hours)");
         $job = new Job();
-        $this->view->result = $job->getTerminatedJobs();
+        $this->view->result = $job->getTerminatedJobs(1);
         if ( empty($this->view->result) ) 
             $this->_helper->viewRenderer->setNoRender();
         else

--- a/application/models/Job.php
+++ b/application/models/Job.php
@@ -116,11 +116,13 @@ class Job extends Zend_Db_Table
 	 * See also http://www.bacula.org/manuals/en/developers/developers/Database_Tables.html
 	 *
 	 */
-    function getTerminatedJobs()
+    function getTerminatedJobs($days)
     {
+        if ( empty($days) ) 
+             $days = 1;
         $select = new Zend_Db_Select($this->db);
         //$select->distinct();
-        $last1day = date('Y-m-d H:i:s', time() - 86400); // для совместимости со старыми версиями mysql: NOW() - INTERVAL 1 DAY
+        $last1day = date('Y-m-d H:i:s', time() - ($days * 86400)); // для совместимости со старыми версиями mysql: NOW() - INTERVAL $days
 
         switch ($this->db_adapter) {
         	case 'PDO_MYSQL':


### PR DESCRIPTION
Added possiblity to define the number of days to show in the "Jobs terminated" view. Otherwise, you must use a search or the timeline view.
